### PR TITLE
feat(genai-client): add Gemini model failover and dynamic selection logic

### DIFF
--- a/.idea/copilot.data.migration.ask2agent.xml
+++ b/.idea/copilot.data.migration.ask2agent.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Ask2AgentMigrationStateService">
+    <option name="migrationStatus" value="COMPLETED" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="2d9c65b9-1d2d-4644-8c29-92f7e288da7d" name="Changes" comment="Final: App working">
+    <list default="true" id="2d9c65b9-1d2d-4644-8c29-92f7e288da7d" name="Changes" comment="feat(api-ui): fix type errors and add null checks">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app.py" beforeDir="false" afterPath="$PROJECT_DIR$/app.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/utils/genai_client.py" beforeDir="false" afterPath="$PROJECT_DIR$/utils/genai_client.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -35,6 +35,7 @@
     "Python.python analysis/trends_over_time.py.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
     "RunOnceActivity.git.unshallow": "true",
     "SHELLCHECK.PATH": "/Users/davidnguyen/Library/Application Support/JetBrains/PyCharm2024.2/plugins/Shell Script/shellcheck",
     "git-widget-placeholder": "master",
@@ -133,9 +134,8 @@
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
-        <option value="bundled-js-predefined-d6986cc7102b-b26f3e71634d-JavaScript-PY-251.26094.141" />
-        <option value="bundled-python-sdk-880ecab49056-36ea0e71a18c-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-251.25410.122" />
-        <option value="bundled-python-sdk-9f8e2b94138c-36ea0e71a18c-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-251.26094.141" />
+        <option value="bundled-js-predefined-d6986cc7102b-3aa1da707db6-JavaScript-PY-252.27397.106" />
+        <option value="bundled-python-sdk-4e2b1448bda8-9a97661f3031-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-252.27397.106" />
       </set>
     </attachedChunks>
   </component>
@@ -152,7 +152,8 @@
       <workItem from="1745809620617" duration="935000" />
       <workItem from="1747625334795" duration="44000" />
       <workItem from="1747625389960" duration="150000" />
-      <workItem from="1751305615759" duration="202000" />
+      <workItem from="1751305615759" duration="275000" />
+      <workItem from="1766722556076" duration="596000" />
     </task>
     <task id="LOCAL-00001" summary="Final: App workin">
       <option name="closed" value="true" />
@@ -474,7 +475,15 @@
       <option name="project" value="LOCAL" />
       <updated>1747625525054</updated>
     </task>
-    <option name="localTasksCounter" value="41" />
+    <task id="LOCAL-00041" summary="feat(api-ui): fix type errors and add null checks">
+      <option name="closed" value="true" />
+      <created>1751305884844</created>
+      <option name="number" value="00041" />
+      <option name="presentableId" value="LOCAL-00041" />
+      <option name="project" value="LOCAL" />
+      <updated>1751305884844</updated>
+    </task>
+    <option name="localTasksCounter" value="42" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -494,11 +503,20 @@
   <component name="VcsManagerConfiguration">
     <MESSAGE value="Final: App workin" />
     <MESSAGE value="Final: App working" />
-    <option name="LAST_COMMIT_MESSAGE" value="Final: App working" />
+    <MESSAGE value="feat(api-ui): fix type errors and add null checks" />
+    <option name="LAST_COMMIT_MESSAGE" value="feat(api-ui): fix type errors and add null checks" />
   </component>
   <component name="com.intellij.coverage.CoverageDataManagerImpl">
     <SUITE FILE_PATH="coverage/PantryPal$python_analysis_ingredient_frequency_py.coverage" NAME="python analysis/ingredient_frequency.py Coverage Results" MODIFIED="1745773543327" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/PantryPal$python_analysis_nutrition_summary_py.coverage" NAME="python analysis/nutrition_summary.py Coverage Results" MODIFIED="1745773863220" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
     <SUITE FILE_PATH="coverage/PantryPal$python_analysis_trends_over_time_py.coverage" NAME="python analysis/trends_over_time.py Coverage Results" MODIFIED="1745773553822" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
+  </component>
+  <component name="github-copilot-workspace">
+    <instructionFileLocations>
+      <option value=".github/instructions" />
+    </instructionFileLocations>
+    <promptFileLocations>
+      <option value=".github/prompts" />
+    </promptFileLocations>
   </component>
 </project>

--- a/utils/genai_client.py
+++ b/utils/genai_client.py
@@ -1,10 +1,18 @@
 import json
 import random
 import re
+import time
 from datetime import datetime
 
 from google import genai
 from google.genai import types
+
+
+_PRO_MODEL_RE = re.compile(r"(^|[-/])pro($|[-])", re.IGNORECASE)
+
+
+class ModelParseError(ValueError):
+    pass
 
 
 class GenAIRecipeGenerator:
@@ -19,6 +27,96 @@ class GenAIRecipeGenerator:
         :param api_key: API key for Google GenAI.
         """
         self.client = genai.Client(api_key=api_key)
+        self._model_cache = []
+        self._model_cache_at = 0.0
+        self._model_index = 0
+
+    def _get_model_attr(self, model, *names):
+        for name in names:
+            if isinstance(model, dict) and name in model:
+                return model[name]
+            if hasattr(model, name):
+                return getattr(model, name)
+        return None
+
+    def _normalize_model_name(self, name: str) -> str:
+        if name.startswith("models/"):
+            return name.split("/", 1)[1]
+        return name
+
+    def _list_gemini_models(self) -> list[str]:
+        raw = self.client.models.list()
+        if isinstance(raw, dict):
+            models = raw.get("models", [])
+        elif hasattr(raw, "models"):
+            models = raw.models
+        else:
+            models = raw
+        candidates = []
+        for model in list(models):
+            name = self._get_model_attr(model, "name")
+            if not name:
+                continue
+            if not name.startswith("models/gemini-") and not name.startswith("gemini-"):
+                continue
+            normalized = self._normalize_model_name(name)
+            name_lower = normalized.lower()
+            if "embedding" in name_lower:
+                continue
+            if _PRO_MODEL_RE.search(name_lower):
+                continue
+            supported = self._get_model_attr(
+                model, "supported_generation_methods", "supportedGenerationMethods"
+            )
+            if supported:
+                supported_lower = {str(method).lower() for method in supported}
+                if (
+                    "generatecontent" not in supported_lower
+                    and "generate_content" not in supported_lower
+                ):
+                    continue
+            candidates.append(normalized)
+        seen = set()
+        filtered = []
+        for name in candidates:
+            if name in seen:
+                continue
+            seen.add(name)
+            filtered.append(name)
+        return filtered
+
+    def _get_available_models(self) -> list[str]:
+        now = time.monotonic()
+        if not self._model_cache or now - self._model_cache_at > 1800:
+            try:
+                models = self._list_gemini_models()
+                if models:
+                    self._model_cache = models
+            except Exception:
+                pass
+            self._model_cache_at = now
+        if self._model_cache:
+            return list(self._model_cache)
+        return ["gemini-1.5-flash", "gemini-2.0-flash-lite"]
+
+    def _request_with_failover(self, request_fn, response_fn):
+        models = self._get_available_models()
+        if not models:
+            raise RuntimeError("No Gemini models available for generation.")
+        start = self._model_index % len(models)
+        last_exc = None
+        for offset in range(len(models)):
+            model = models[(start + offset) % len(models)]
+            try:
+                response = request_fn(model)
+                result = response_fn(response)
+                self._model_index = (start + offset + 1) % len(models)
+                return result
+            except Exception as exc:
+                last_exc = exc
+        if last_exc:
+            raise last_exc
+        raise RuntimeError("Gemini request failed without a captured exception.")
 
     def generate(self, ings, restrs, serves):
         """
@@ -96,19 +194,24 @@ class GenAIRecipeGenerator:
             "Output ONLY the JSON object."
         )
 
-        resp = self.client.models.generate_content(
-            model="gemini-1.5-flash",
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                system_instruction=sys,
-                temperature=temp,
-                top_p=top_p,
-                top_k=top_k,
-                max_output_tokens=8192,
-                response_mime_type="application/json",
-            ),
-        )
-        return json.loads(resp.text)
+        def request(model):
+            return self.client.models.generate_content(
+                model=model,
+                contents=prompt,
+                config=types.GenerateContentConfig(
+                    system_instruction=sys,
+                    temperature=temp,
+                    top_p=top_p,
+                    top_k=top_k,
+                    max_output_tokens=8192,
+                    response_mime_type="application/json",
+                ),
+            )
+
+        def parse_response(resp):
+            return json.loads(resp.text)
+
+        return self._request_with_failover(request, parse_response)
 
     def get_substitutions(self, missing: list[str]) -> dict[str, list[str]]:
         """
@@ -130,29 +233,35 @@ class GenAIRecipeGenerator:
         prompt = (
             f"Missing ingredients: {', '.join(missing)}.\nOutput ONLY the JSON mapping."
         )
-        resp = self.client.models.generate_content(
-            model="gemini-2.0-flash-lite",
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                system_instruction=sys,
-                temperature=0.7,
-                top_p=0.9,
-                top_k=32,
-                max_output_tokens=512,
-                response_mime_type="application/json",
-            ),
-        )
 
-        text = resp.text
+        def request(model):
+            return self.client.models.generate_content(
+                model=model,
+                contents=prompt,
+                config=types.GenerateContentConfig(
+                    system_instruction=sys,
+                    temperature=0.7,
+                    top_p=0.9,
+                    top_k=32,
+                    max_output_tokens=512,
+                    response_mime_type="application/json",
+                ),
+            )
+
+        def parse_response(resp):
+            text = resp.text
+            try:
+                return json.loads(text)
+            except json.JSONDecodeError:
+                m = re.search(r"(\{.*\})", text, re.DOTALL)
+                if m:
+                    try:
+                        return json.loads(m.group(1))
+                    except json.JSONDecodeError:
+                        pass
+                raise ModelParseError("Gemini substitutions response was not valid JSON.")
+
         try:
-            return json.loads(text)
-        except json.JSONDecodeError:
-            # attempt to extract the first {...} block
-            m = re.search(r"(\{.*\})", text, re.DOTALL)
-            if m:
-                try:
-                    return json.loads(m.group(1))
-                except json.JSONDecodeError:
-                    pass
-            # fallback to empty map
+            return self._request_with_failover(request, parse_response)
+        except ModelParseError:
             return {}


### PR DESCRIPTION
This pull request mainly refactors the `GenAIRecipeGenerator` class in `utils/genai_client.py` to improve reliability and error handling when interacting with the Google GenAI API. It introduces model selection failover, response parsing improvements, and adds caching for available models. There are also minor updates to project configuration files related to IDE state and migration.

**GenAI API client improvements:**

* Added model selection failover logic in `GenAIRecipeGenerator`, allowing automatic retries with alternative Gemini models if a request fails. This includes model caching and filtering to avoid unsupported or pro models. (`utils/genai_client.py`) [[1]](diffhunk://#diff-e5efca3075e9e8b3fd1089048387e76346192d09d5281830814d473aef408244R4-R17) [[2]](diffhunk://#diff-e5efca3075e9e8b3fd1089048387e76346192d09d5281830814d473aef408244R30-R119)
* Improved response parsing in both `generate` and `get_substitutions` methods, with better error handling for invalid or malformed JSON responses. A custom `ModelParseError` exception was introduced for clearer error signaling. (`utils/genai_client.py`) [[1]](diffhunk://#diff-e5efca3075e9e8b3fd1089048387e76346192d09d5281830814d473aef408244R210-R215) [[2]](diffhunk://#diff-e5efca3075e9e8b3fd1089048387e76346192d09d5281830814d473aef408244R251-R266)
* Updated both `generate` and `get_substitutions` methods to use the new failover and parsing logic, making the class more robust to API errors and model changes. (`utils/genai_client.py`) [[1]](diffhunk://#diff-e5efca3075e9e8b3fd1089048387e76346192d09d5281830814d473aef408244L99-R199) [[2]](diffhunk://#diff-e5efca3075e9e8b3fd1089048387e76346192d09d5281830814d473aef408244L133-R239)

**Project/IDE configuration updates:**

* Added `.idea/copilot.data.migration.ask2agent.xml` to mark a Copilot migration as completed.
* Updated `.idea/workspace.xml` with new task metadata, shared index versions, and Copilot workspace locations to reflect recent development activity. [[1]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL7-R9) [[2]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cR38) [[3]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL136-R138) [[4]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL155-R156) [[5]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL477-R486) [[6]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL497-R521)